### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins 

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
 		"checkJs": true,
 		"lib": ["ES2021"],
-		"moduleResolution": "nodenext",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"resolveJsonModule": true,
 		"target": "ES2021"
 	},

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"author": "Frazer Smith <frazer.dev@outlook.com>",
 	"funding": "https://github.com/sponsors/Fdawgs",
 	"engines": {
-		"node": ">=14.0.0"
+		"node": ">=14.18.0"
 	},
 	"scripts": {
 		"jest": "jest",

--- a/scripts/license-checker.js
+++ b/scripts/license-checker.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const { promisify } = require("util");
+const { promisify } = require("node:util");
 const { init } = require("license-checker");
 // @ts-ignore
 const copyLeftLicenses = require("spdx-copyleft");


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/37246/files#r588397158