### PR TITLE
ci(cd): use oicd for publishing to npm

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,15 +54,14 @@ jobs:
                   registry-url: https://registry.npmjs.org
 
             - name: Publish to NPM
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               # Build docs/definitions, and remove dev values
               # from package.json before publishing to reduce package size
               run: |
+                  npm i -g npm@latest
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts
-                  npm publish --access public --ignore-scripts --provenance
+                  npm publish --access public --ignore-scripts
 
     publish-ghp:
         name: Publish to GitHub Packages
@@ -103,6 +102,7 @@ jobs:
               # Build docs/definitions, and remove dev values
               # from package.json before publishing to reduce package size
               run: |
+                  npm i -g npm@latest
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts


### PR DESCRIPTION
This is a batch PR created by a script. Please review prior to merging.