### PR TITLE
build(deps): replace accepts with negotiator

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
 		"@commitlint/cli": "^20.1.0",
 		"@commitlint/config-conventional": "^20.0.0",
 		"@fdawgs/eslint-config": "^3.0.0",
-		"@types/accepts": "^1.3.7",
 		"@types/negotiator": "^0.6.5",
 		"@types/node": "^26.0.0",
 		"c8": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"@commitlint/config-conventional": "^20.0.0",
 		"@fdawgs/eslint-config": "^3.0.0",
 		"@types/accepts": "^1.3.7",
+		"@types/negotiator": "^0.6.5",
 		"@types/node": "^26.0.0",
 		"c8": "^12.0.0",
 		"eslint": "^10.4.0",
@@ -61,9 +62,9 @@
 		"typescript": "~6.0.2"
 	},
 	"dependencies": {
-		"accepts": "^1.3.8",
 		"fastify-plugin": "^6.0.0",
 		"js2xmlparser": "^5.0.0",
+		"negotiator": "^1.0.0",
 		"secure-json-parse": "^4.1.0"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const fp = require("fastify-plugin");
-const accepts = require("accepts");
+const Negotiator = require("negotiator");
 const { parse: xmlParse } = require("js2xmlparser");
 const { parse: secureParse } = require("secure-json-parse");
 
@@ -45,7 +45,8 @@ function fastifyJsonToXml(server, options, done) {
 					?.toString()
 					.toLowerCase()
 					.includes("application/json") &&
-				accepts(req.raw).type(ACCEPTED_TYPES) === "application/xml"
+				new Negotiator(req.raw).mediaType(ACCEPTED_TYPES) ===
+					"application/xml"
 			) {
 				res.type("application/xml; charset=utf-8");
 				return xmlParse(


### PR DESCRIPTION
`accepts` wraps `negotiator` and is the only part of `accepts` this package actually uses.
The rest of the `accepts` is mime-db, which isn't used.

`accepts` is 264kB vs `negotiator`'s 46.4kB.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
